### PR TITLE
Optimized execread using triple buffering

### DIFF
--- a/input/input.go
+++ b/input/input.go
@@ -72,3 +72,10 @@ func MakeBuffers(cfg SessionConfig) [][]Sample {
 	}
 	return buf
 }
+
+// CopyBuffers deep copies src to dst. It does NOT do length check.
+func CopyBuffers(dst, src [][]Sample) {
+	for i := range src {
+		copy(dst[i], src[i])
+	}
+}


### PR DESCRIPTION
This commit adds a third buffer into execread to reduce lock contention. It also makes ReadyRead non-blocking.