### PR TITLE
fix #25: prevent avfoundation printing to stderr

### DIFF
--- a/input/common/execread/execread.go
+++ b/input/common/execread/execread.go
@@ -20,6 +20,10 @@ type Session struct {
 	// OnStart is called when the session starts. Nil by default.
 	OnStart func(ctx context.Context, cmd *exec.Cmd) error
 
+	// prevents cmd.Stderr from poiting to os.Stderr. false by default.
+	// this is a hack for github noriah/catnip#25
+	DisconnectedStderr bool
+
 	argv []string
 	cfg  input.SessionConfig
 
@@ -49,7 +53,10 @@ func (s *Session) Start(ctx context.Context, dst [][]input.Sample, kickChan chan
 	}
 
 	cmd := exec.CommandContext(ctx, s.argv[0], s.argv[1:]...)
-	cmd.Stderr = os.Stderr
+
+	if !s.DisconnectedStderr {
+		cmd.Stderr = os.Stderr
+	}
 
 	o, err := cmd.StdoutPipe()
 	if err != nil {

--- a/input/ffmpeg/avfoundation.go
+++ b/input/ffmpeg/avfoundation.go
@@ -115,7 +115,13 @@ func (p AVFoundation) Start(cfg input.SessionConfig) (input.Session, error) {
 		return nil, fmt.Errorf("invalid device type %T", cfg.Device)
 	}
 
-	return NewSession(dv, cfg)
+	session, err := NewSession(dv, cfg)
+
+	// HACK(github noriah/catnip#25) ffmpeg avfoundation (darwin) unconditionally
+	// prints errors even with loglevel set to panic or quiet.
+	session.DisconnectedStderr = true
+
+	return session, err
 }
 
 type AVFoundationDevice struct {


### PR DESCRIPTION
this is a hack at best. ideally ffmpeg avfoundation would respect -loglevel